### PR TITLE
Added an extra condition for the pidfile check

### DIFF
--- a/cmd/run
+++ b/cmd/run
@@ -144,7 +144,12 @@ _run() {
   fi
 
   if [[ -f "${VMRUN}/pidfile" ]]; then
-    _fatal 1 "'${VMRUN}/pidfile' exists; vm might already be running"
+    if pidof "$QEMU_SYSTEM_BINARY" >/dev/null; then 
+      _fatal 1 "'${VMRUN}/pidfile' exists; vm might already be running"
+    else
+      _log "removing the stale '${VMRUN}/pidfile'"
+      rm -f "${VMRUN}/pidfile"
+    fi
   fi
 
   local setup_fn


### PR DESCRIPTION
When there is an ungraceful shutdown of the system, the pidfile is not removed by the qemu. In that case, using the run command throws an error because the pidfile already exists. 

Added an extra condition which checks also if the qemu process is also running. Tested in my system by adding a dummy pidfile before the `run` command. 