### PR TITLE
Error while running example subsys.conf

### DIFF
--- a/examples/vm/subsys.conf
+++ b/examples/vm/subsys.conf
@@ -28,7 +28,7 @@ _setup_subsys() {
   # nvme namespace
   qemu_nvme_add_ns "nvm-1" \
     --nsid "1" \
-    --subsys "subsys0" \
+    --ctrl "ctrl0" \
     --size "1G" \
     --extra "$default_nvme_ns_extra"
 }


### PR DESCRIPTION
subsys option does not exist for qemu_nvme_add_ns, therefore, the example is throwing an error. 
Removed that option and replaced it with `ctrl` option. 