### PR TITLE
Add note about dependency to avoid error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ key. Place the output image (`seed.img`) in `img/` and pass the `--cloud-init`
 cloud-init will automatically power off the virtual machine when it has been
 configured.
 
+NOTE: For the cloud-config helper script to work `cloud-utils` is required.
+
 [cloud-init]: https://cloudinit.readthedocs.io/en/latest/
 
 


### PR DESCRIPTION
When running `./contrib/generate-cloud-config-seed.sh ~/.ssh/id_rsa.pub`  without having `cloud-utils` installed the following error is encountered: 
```bash
$ ./contrib/generate-cloud-config-seed.sh: line 100: cloud-localds: command not found
```
Add a note to the readme to avoid confusion.


Signed-off-by: Karl Bonde Torp <karlowich@gmail.com>