### PR TITLE
Add a pre and post hook to run before and after running QEMU

### DIFF
--- a/cmd/run
+++ b/cmd/run
@@ -267,6 +267,10 @@ _run() {
     exit 0
   fi
 
+  if command -v _pre > /dev/null; then
+	  _pre
+  fi
+
   if [[ -v do_gdb ]]; then
     gdb -ex "handle SIGUSR1 pass noprint" -ex "handle SIGPIPE nostop" --args "$QEMU_SYSTEM_BINARY" "${params[@]}"
   else
@@ -286,5 +290,9 @@ _run() {
     else
       $QEMU_SYSTEM_BINARY "${params[@]}"
     fi
+  fi
+
+  if command -v _post > /dev/null; then
+	  _post
   fi
 }

--- a/examples/vm/nvme.conf
+++ b/examples/vm/nvme.conf
@@ -23,3 +23,23 @@ _setup_nvme() {
     --size "1G" \
     --extra "$default_nvme_ns_extra"
 }
+
+_pre() {
+	# Pre hook to run before starting QEMU
+
+	# unbind 0000:01:00.0 from nvme kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/nvme/unbind
+
+	# bind 0000:01:00.0 to vfio-pci kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/vfio-pci/bind
+}
+
+_post() {
+	# Post hook to run after exiting QEMU
+
+	# unbind 0000:01:00.0 from vfio-pci kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/vfio-pci/unbind
+
+	# bind 0000:01:00.0 to xhci_hcd kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/nvme/bind
+}

--- a/examples/vm/zns.conf
+++ b/examples/vm/zns.conf
@@ -15,3 +15,23 @@ _setup_zns() {
     --size "1G" \
     --extra "$default_nvme_ns_extra,zoned=true,zoned.zone_capacity=12M,zoned.zone_size=16M"
 }
+
+_pre() {
+	# Pre hook to run before starting QEMU
+
+	# unbind 0000:01:00.0 from nvme kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/nvme/unbind
+
+	# bind 0000:01:00.0 to vfio-pci kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/vfio-pci/bind
+}
+
+_post() {
+	# Post hook to run after exiting QEMU
+
+	# unbind 0000:01:00.0 from vfio-pci kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/vfio-pci/unbind
+
+	# bind 0000:01:00.0 to xhci_hcd kernel module
+	# echo '0000:01:00.0' > /sys/bus/pci/drivers/nvme/bind
+}


### PR DESCRIPTION
Pre & post hooks are added that can run before starting QEMU and after exiting QEMU. These hooks can come in handy while doing vfio passthrough to bind/unbind the relevant device for passthrough.

Signed-off-by: Pankaj Raghav <p.raghav@samsung.com>